### PR TITLE
V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 cache.json
 src/*.js
 dist
+media/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
-2.0.0
+# 2.0.0
 
 - The `/u` endpoint has been renamed to `/fromTwitter`
+- Add a `/fromMastodon` endpoint, this endpoint will post to:
+  - Cohost
+    - Content warnings and audio attachments are supported
+  - Bluesky
+    - If the Mastodon post is too long, it will be posted as a tweet with a link to the original post
+    - If the Mastodon post has a content warning, it will be posted as a tweet with a link to the original post
+  - Twitter
+    - If the Mastodon post is too long, it will be posted as a tweet with a link to the original post
+    - If the Mastodon post has a content warning, it will be posted as a tweet with a link to the original post
+- media files are now stored in the `media` folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+2.0.0
+
+- The `/u` endpoint has been renamed to `/fromTwitter`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@
     - If the Mastodon post is too long, it will be posted as a tweet with a link to the original post
     - If the Mastodon post has a content warning, it will be posted as a tweet with a link to the original post
 - media files are now stored in the `media` folder
+- The `docker` npm script has been removed. The installation of dependencies and building of the project is now in the setup of the Docker container.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   app:
     image: node:22-alpine
-    command: sh -c "node dist/server.js"
+    command: sh -c "npm ci && npm run build && node dist/server.js"
     ports:
       - 8080:80
     working_dir: /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "masto": "^6.8.0",
         "mime-types": "^2.1.35",
         "prettier": "^3.3.3",
+        "sharp": "^0.33.5",
         "tsx": "^4.19.0",
         "twitter-api-v2": "^1.17.2",
         "typescript": "^5.5.4",
@@ -102,6 +103,16 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.0.tgz",
+      "integrity": "sha512-XMBySMuNZs3DM96xcJmLW4EfGnf+uGmFNjzpehMjuX5PLB5j87ar2Zc4e3PVeZ3I5g3tYtAqskB28manlF69Zw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -486,6 +497,367 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@types/body-parser": {
@@ -1384,6 +1756,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/director": {
@@ -3655,6 +4036,18 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
+    "node_modules/semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
@@ -3725,6 +4118,76 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
+    },
+    "node_modules/sharp/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/sharp/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/shush": {
       "version": "1.0.3",
@@ -4672,6 +5135,15 @@
         "kuler": "^2.0.0"
       }
     },
+    "@emnapi/runtime": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.3.0.tgz",
+      "integrity": "sha512-XMBySMuNZs3DM96xcJmLW4EfGnf+uGmFNjzpehMjuX5PLB5j87ar2Zc4e3PVeZ3I5g3tYtAqskB28manlF69Zw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.4.0"
+      }
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
@@ -4814,6 +5286,147 @@
       "version": "0.23.1",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
       "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "optional": true
+    },
+    "@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "optional": true
+    },
+    "@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "optional": true
+    },
+    "@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "optional": true
+    },
+    "@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "optional": true
+    },
+    "@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "optional": true
+    },
+    "@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "optional": true
+    },
+    "@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "optional": true
+    },
+    "@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "optional": true
+    },
+    "@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "optional": true,
+      "requires": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "optional": true,
+      "requires": {
+        "@emnapi/runtime": "^1.2.0"
+      }
+    },
+    "@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "optional": true
+    },
+    "@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
       "optional": true
     },
     "@types/body-parser": {
@@ -5551,6 +6164,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
     },
     "director": {
       "version": "1.2.7",
@@ -7276,6 +7894,11 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
+    "semver": {
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+    },
     "send": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
@@ -7339,6 +7962,59 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "requires": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5",
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "dependencies": {
+        "color": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+          "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+          "requires": {
+            "color-convert": "^2.0.1",
+            "color-string": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
     },
     "shush": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "mime-types": "^2.1.35",
         "prettier": "^3.3.3",
         "tsx": "^4.19.0",
+        "twitter-api-v2": "^1.17.2",
         "typescript": "^5.5.4",
         "undici": "^6.19.8"
       }
@@ -4201,6 +4202,12 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/twitter-api-v2": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.17.2.tgz",
+      "integrity": "sha512-V8QvCkuQ+ydIakwYbVC4cuQxGlvjdRZI0L7TT5v9zGsf+SwX40rv3IFRHB8Z1cXJLcRFT0FI3xG3/f4zwS6cRA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -7711,6 +7718,11 @@
         "fsevents": "~2.3.3",
         "get-tsconfig": "^4.7.5"
       }
+    },
+    "twitter-api-v2": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.17.2.tgz",
+      "integrity": "sha512-V8QvCkuQ+ydIakwYbVC4cuQxGlvjdRZI0L7TT5v9zGsf+SwX40rv3IFRHB8Z1cXJLcRFT0FI3xG3/f4zwS6cRA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "mime-types": "^2.1.35",
     "prettier": "^3.3.3",
     "tsx": "^4.19.0",
+    "twitter-api-v2": "^1.17.2",
     "typescript": "^5.5.4",
     "undici": "^6.19.8"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "masto": "^6.8.0",
     "mime-types": "^2.1.35",
     "prettier": "^3.3.3",
+    "sharp": "^0.33.5",
     "tsx": "^4.19.0",
     "twitter-api-v2": "^1.17.2",
     "typescript": "^5.5.4",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "typecheck": "tsc --noEmit -p .",
     "start": "tsx src/server.ts",
     "dev": "tsx watch src/server.ts",
-    "serve": "forever stop 'tweet-forker'; forever --uid='tweet-forker' --append start src/server.js",
-    "docker": "npm ci && npm run build && docker compose up -d"
+    "serve": "forever stop 'tweet-forker'; forever --uid='tweet-forker' --append start src/server.js"
   },
   "keywords": [],
   "author": "",

--- a/src/bsky.ts
+++ b/src/bsky.ts
@@ -3,7 +3,7 @@ import fs from "fs";
 import mime from "mime-types";
 import path from "path";
 import { getReplyingTo } from "./fxTwitterHelpers";
-import { DownloadedMedia } from "./media";
+import { DownloadedMedia } from "./helpers/commonTypes";
 import { findBlueskyPostFromTweetId } from "./storage";
 
 export async function postTweetToBluesky(

--- a/src/bsky.ts
+++ b/src/bsky.ts
@@ -4,7 +4,7 @@ import mime from "mime-types";
 import path from "path";
 import { getReplyingTo } from "./fxTwitterHelpers";
 import { DownloadedMedia } from "./media";
-import { findSkeetFromTweetId } from "./storage";
+import { findBlueskyPostFromTweetId } from "./storage";
 
 export async function postTweetToBluesky(
   tweet: APITweet,
@@ -45,7 +45,7 @@ export async function postTweetToBluesky(
   await rt.detectFacets(agent);
 
   const replyToId = getReplyingTo(tweet);
-  const maybeInReplyToId = replyToId && findSkeetFromTweetId(replyToId);
+  const maybeInReplyToId = replyToId && findBlueskyPostFromTweetId(replyToId);
   console.log(`[bsky] in reply to ${maybeInReplyToId}]`);
 
   const uriP = maybeInReplyToId ? new AtUri(maybeInReplyToId) : undefined;

--- a/src/cohost.ts
+++ b/src/cohost.ts
@@ -2,7 +2,7 @@
 import cohost from "cohost";
 import path from "node:path";
 import { getReplyingTo } from "./fxTwitterHelpers";
-import { DownloadedMedia } from "./media";
+import { DownloadedMedia } from "./helpers/commonTypes";
 import { findChostFromTweetId } from "./storage";
 
 export async function postTweetToCohost(

--- a/src/fxTwitterHelpers.ts
+++ b/src/fxTwitterHelpers.ts
@@ -1,6 +1,0 @@
-export function getReplyingTo(tweet: APITweet) {
-  if (tweet.replying_to_status) {
-    return tweet.replying_to_status;
-  }
-  return tweet.replying_to_status ?? tweet.replying_to?.post ?? null;
-}

--- a/src/helpers/bsky.ts
+++ b/src/helpers/bsky.ts
@@ -1,11 +1,19 @@
-import { AtUri, AtpAgent, RichText } from "@atproto/api";
+import {
+  AppBskyEmbedExternal,
+  AppBskyEmbedImages,
+  AtUri,
+  AtpAgent,
+  RichText,
+} from "@atproto/api";
 import fs from "fs";
 import mime from "mime-types";
-import path from "path";
 import { findPost } from "../storage";
 import { DownloadedMedia } from "./commonTypes";
-import { getTweetReplyingTo } from "./twitter";
 import { makeMediaFilepath } from "./media";
+import { getTweetReplyingTo } from "./twitter";
+import { mastodon } from "masto";
+import { getMastodonStatusInReplyTo } from "./mastodon";
+import { stream } from "undici";
 
 export async function postTweetToBluesky(
   tweet: APITweet,
@@ -87,6 +95,126 @@ export async function postTweetToBluesky(
           }),
         }
       : undefined,
+  });
+
+  return res;
+}
+
+export async function postMastodonToBluesky(
+  status: mastodon.v1.Status,
+  source: mastodon.v1.StatusSource,
+  mediaFiles: ReadonlyArray<DownloadedMedia>,
+) {
+  const agent = new AtpAgent({ service: "https://staging.bsky.social" });
+
+  console.log("[bsky] login");
+  const text = source.text;
+  await agent.login({
+    identifier: process.env.BSKY_ID || "",
+    password: process.env.BSKY_PASSWORD || "",
+  });
+
+  if (mediaFiles.length > 0) {
+    console.log("[bsky] upload images");
+  }
+  const imageRecords = await Promise.all(
+    mediaFiles.slice(0, 4).map((photo) => {
+      return new Promise<Awaited<ReturnType<typeof agent.uploadBlob>>>(
+        async (resolve) => {
+          console.log(`[bsky] uploading ${photo.filename}`);
+          const response = await agent.uploadBlob(
+            fs.readFileSync(makeMediaFilepath(photo.filename)),
+            {
+              encoding: mime.lookup(makeMediaFilepath(photo.filename)) || "",
+            },
+          );
+
+          resolve(response);
+        },
+      );
+    }),
+  );
+
+  console.log("[bsky] text formatting");
+  const rt = new RichText({ text: text });
+  await rt.detectFacets(agent);
+
+  const replyToId = getMastodonStatusInReplyTo(status);
+  const maybeInReplyToId =
+    replyToId && findPost.fromMastodon.toBluesky(replyToId);
+  console.log(`[bsky] in reply to ${maybeInReplyToId}]`);
+
+  const uriP = maybeInReplyToId ? new AtUri(maybeInReplyToId) : undefined;
+  const parentPost = uriP
+    ? await agent.getPost({
+        repo: uriP.host,
+        rkey: uriP.rkey,
+      })
+    : undefined;
+
+  const parentRef = parentPost
+    ? {
+        uri: parentPost.uri,
+        cid: parentPost.cid,
+      }
+    : undefined;
+
+  let embed: AppBskyEmbedImages.Main | AppBskyEmbedExternal.Main | undefined =
+    undefined;
+
+  if (imageRecords.length) {
+    embed = {
+      $type: "app.bsky.embed.images",
+      images: imageRecords.map((r, index) => {
+        return {
+          image: r.data.blob,
+          alt: mediaFiles[index]?.altText || "",
+        };
+      }),
+    };
+  }
+
+  if (status.card) {
+    embed = {
+      $type: "app.bsky.embed.external",
+      external: {
+        description: status.card.description,
+        title: status.card.title,
+        descriptionHtml: status.card.description || "",
+        uri: status.card.url,
+      },
+    };
+
+    if (status.card.image) {
+      await stream(status.card.image, { method: "GET" }, () =>
+        fs.createWriteStream(makeMediaFilepath(status.card!.image!)),
+      );
+
+      const cardImageRecord = await agent.uploadBlob(
+        fs.readFileSync(makeMediaFilepath(status.card!.image!)),
+        {
+          encoding: mime.lookup(makeMediaFilepath(status.card.image!)) || "",
+        },
+      );
+
+      embed.external.thumb = cardImageRecord.data.blob;
+
+      fs.unlinkSync(makeMediaFilepath(status.card!.image!));
+    }
+  }
+
+  const res = await agent.post({
+    $type: "app.bsky.feed.post",
+    text: rt.text,
+    facets: rt.facets,
+    reply:
+      parentPost && parentRef
+        ? {
+            root: parentPost.value.reply?.root || parentRef,
+            parent: parentRef,
+          }
+        : undefined,
+    embed,
   });
 
   return res;

--- a/src/helpers/bsky.ts
+++ b/src/helpers/bsky.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { findPost } from "../storage";
 import { DownloadedMedia } from "./commonTypes";
 import { getTweetReplyingTo } from "./twitter";
+import { makeMediaFilepath } from "./media";
 
 export async function postTweetToBluesky(
   tweet: APITweet,
@@ -28,9 +29,9 @@ export async function postTweetToBluesky(
         async (resolve) => {
           console.log(`[bsky] uploading ${photo.filename}`);
           const response = await agent.uploadBlob(
-            fs.readFileSync(path.basename(photo.filename)),
+            fs.readFileSync(makeMediaFilepath(photo.filename)),
             {
-              encoding: mime.lookup(path.basename(photo.filename)) || "",
+              encoding: mime.lookup(makeMediaFilepath(photo.filename)) || "",
             },
           );
 

--- a/src/helpers/bsky.ts
+++ b/src/helpers/bsky.ts
@@ -2,9 +2,9 @@ import { AtUri, AtpAgent, RichText } from "@atproto/api";
 import fs from "fs";
 import mime from "mime-types";
 import path from "path";
-import { getReplyingTo } from "../fxTwitterHelpers";
+import { findPost } from "../storage";
 import { DownloadedMedia } from "./commonTypes";
-import { findBlueskyPostFromTweetId } from "../storage";
+import { getTweetReplyingTo } from "./twitter";
 
 export async function postTweetToBluesky(
   tweet: APITweet,
@@ -44,8 +44,9 @@ export async function postTweetToBluesky(
   const rt = new RichText({ text: text });
   await rt.detectFacets(agent);
 
-  const replyToId = getReplyingTo(tweet);
-  const maybeInReplyToId = replyToId && findBlueskyPostFromTweetId(replyToId);
+  const replyToId = getTweetReplyingTo(tweet);
+  const maybeInReplyToId =
+    replyToId && findPost.fromTwitter.toBluesky(replyToId);
   console.log(`[bsky] in reply to ${maybeInReplyToId}]`);
 
   const uriP = maybeInReplyToId ? new AtUri(maybeInReplyToId) : undefined;

--- a/src/helpers/bsky.ts
+++ b/src/helpers/bsky.ts
@@ -2,9 +2,9 @@ import { AtUri, AtpAgent, RichText } from "@atproto/api";
 import fs from "fs";
 import mime from "mime-types";
 import path from "path";
-import { getReplyingTo } from "./fxTwitterHelpers";
-import { DownloadedMedia } from "./helpers/commonTypes";
-import { findBlueskyPostFromTweetId } from "./storage";
+import { getReplyingTo } from "../fxTwitterHelpers";
+import { DownloadedMedia } from "./commonTypes";
+import { findBlueskyPostFromTweetId } from "../storage";
 
 export async function postTweetToBluesky(
   tweet: APITweet,

--- a/src/helpers/cohost.ts
+++ b/src/helpers/cohost.ts
@@ -1,9 +1,9 @@
 // @ts-expect-error
 import cohost from "cohost";
 import path from "node:path";
-import { getReplyingTo } from "./fxTwitterHelpers";
-import { DownloadedMedia } from "./helpers/commonTypes";
-import { findChostFromTweetId } from "./storage";
+import { getReplyingTo } from "../fxTwitterHelpers";
+import { findChostFromTweetId } from "../storage";
+import { DownloadedMedia } from "./commonTypes";
 
 export async function postTweetToCohost(
   tweet: APITweet,
@@ -24,8 +24,7 @@ export async function postTweetToCohost(
   }
 
   // ugly-ass hack because im too lazy to do proper markdown here
-  let text = tweet.text.replaceAll("\n", "<br />");
-  text = text + (tweet.quote?.url ? `<br/><br/>${tweet.quote?.url}` : ``);
+  const text = tweet.text.replaceAll("\n", "<br />");
 
   const tweetReplyToId = getReplyingTo(tweet);
 

--- a/src/helpers/cohost.ts
+++ b/src/helpers/cohost.ts
@@ -105,12 +105,19 @@ export async function postMastodonToCohost(
     return undefined;
   }
 
-  const text = source.text;
+  let text = source.text;
   const contentWarnings = source.spoilerText
     ? source.spoilerText.split(",").map((s) => s.trim())
     : [];
 
   const mastodonReplyToId = getMastodonStatusInReplyTo(status);
+
+  if (status.card) {
+    text = text.replace(
+      new RegExp(status.card.url + "$"),
+      `\n\n${status.card.url}`,
+    );
+  }
 
   const basePost = {
     postState: 0,

--- a/src/helpers/cohost.ts
+++ b/src/helpers/cohost.ts
@@ -105,7 +105,7 @@ export async function postMastodonToCohost(
     return undefined;
   }
 
-  const text = source.text.replaceAll("\n", "<br />");
+  const text = source.text;
   const contentWarnings = source.spoilerText
     ? source.spoilerText.split(",").map((s) => s.trim())
     : [];
@@ -129,8 +129,6 @@ export async function postMastodonToCohost(
         Number(findPost.fromMastodon.toCohost(mastodonReplyToId))) ||
       undefined,
   };
-
-  console.log({ mastodonReplyToId, basePost });
 
   const draftId = await cohost.Post.create(projectToPostTo, basePost);
   const attachmentsData = await Promise.all(

--- a/src/helpers/commonTypes.ts
+++ b/src/helpers/commonTypes.ts
@@ -1,0 +1,4 @@
+export type DownloadedMedia = {
+  altText: string;
+  filename: string;
+};

--- a/src/helpers/mastodon.ts
+++ b/src/helpers/mastodon.ts
@@ -1,9 +1,11 @@
 import fs from "fs";
 import { createRestAPIClient, mastodon } from "masto";
 import path from "path";
-import { findTootFromTweetId } from "../storage";
+import { findPost } from "../storage";
 import { DownloadedMedia } from "./commonTypes";
-import { getReplyingTo } from "../fxTwitterHelpers";
+import { getTweetReplyingTo } from "./twitter";
+
+export class MastodonStatusNotFoundError extends Error {}
 
 export async function postTweetToMastodon(
   tweet: APITweet,
@@ -38,8 +40,9 @@ export async function postTweetToMastodon(
     }),
   );
 
-  const inReplyTo = getReplyingTo(tweet);
-  const maybeInReplyToId = inReplyTo && findTootFromTweetId(inReplyTo);
+  const inReplyTo = getTweetReplyingTo(tweet);
+  const maybeInReplyToId =
+    inReplyTo && findPost.fromTwitter.toMastodon(inReplyTo);
 
   const status = await masto.v1.statuses.create({
     status: text,
@@ -78,4 +81,6 @@ export async function getStatusAndSourceFromMastodonUrl(url: string): Promise<{
   return { status, source };
 }
 
-export class MastodonStatusNotFoundError extends Error {}
+export function getMastodonStatusInReplyTo(status: mastodon.v1.Status) {
+  return status.inReplyToId;
+}

--- a/src/helpers/mastodon.ts
+++ b/src/helpers/mastodon.ts
@@ -1,9 +1,9 @@
 import fs from "fs";
 import { createRestAPIClient, mastodon } from "masto";
 import path from "path";
-import { findTootFromTweetId } from "./storage";
-import { DownloadedMedia } from "./helpers/commonTypes";
-import { getReplyingTo } from "./fxTwitterHelpers";
+import { findTootFromTweetId } from "../storage";
+import { DownloadedMedia } from "./commonTypes";
+import { getReplyingTo } from "../fxTwitterHelpers";
 
 export async function postTweetToMastodon(
   tweet: APITweet,
@@ -51,7 +51,7 @@ export async function postTweetToMastodon(
   return status;
 }
 
-export async function getJsonFromMastodon(url: string): Promise<{
+export async function getStatusAndSourceFromMastodonUrl(url: string): Promise<{
   status: mastodon.v1.Status;
   source: mastodon.v1.StatusSource;
 }> {

--- a/src/helpers/media.ts
+++ b/src/helpers/media.ts
@@ -1,0 +1,5 @@
+import path from "path";
+
+export function makeMediaFilepath(url: string) {
+  return path.resolve("media/", path.basename(url));
+}

--- a/src/helpers/twitter.ts
+++ b/src/helpers/twitter.ts
@@ -24,3 +24,9 @@ export async function downloadTwitterMedia(tweet: APITweet) {
     }),
   );
 }
+export function getTweetReplyingTo(tweet: APITweet) {
+  if (tweet.replying_to_status) {
+    return tweet.replying_to_status;
+  }
+  return tweet.replying_to_status ?? tweet.replying_to?.post ?? null;
+}

--- a/src/helpers/twitter.ts
+++ b/src/helpers/twitter.ts
@@ -1,13 +1,9 @@
 import { stream } from "undici";
 import fs from "node:fs";
 import path from "node:path";
+import { DownloadedMedia } from "./commonTypes";
 
-export type DownloadedMedia = {
-  altText: string;
-  filename: string;
-};
-
-export async function downloadMedia(tweet: APITweet) {
+export async function downloadTwitterMedia(tweet: APITweet) {
   return await Promise.all(
     (tweet.media?.photos || tweet.media?.videos || []).map((photoOrVideo) => {
       return new Promise<DownloadedMedia>(async (resolve) => {

--- a/src/helpers/twitter.ts
+++ b/src/helpers/twitter.ts
@@ -1,8 +1,11 @@
+import { TwitterApi } from "twitter-api-v2";
 import { stream } from "undici";
 import fs from "node:fs";
 import path from "node:path";
 import { DownloadedMedia } from "./commonTypes";
 import { makeMediaFilepath } from "./media";
+import { mastodon } from "masto";
+import { findPost } from "../storage";
 
 export async function downloadTwitterMedia(tweet: APITweet) {
   return await Promise.all(
@@ -30,4 +33,78 @@ export function getTweetReplyingTo(tweet: APITweet) {
     return tweet.replying_to_status;
   }
   return tweet.replying_to_status ?? tweet.replying_to?.post ?? null;
+}
+
+export async function postMastodonToTwitter(
+  status: mastodon.v1.Status,
+  source: mastodon.v1.StatusSource,
+  mediaFiles: ReadonlyArray<DownloadedMedia>,
+) {
+  try {
+    console.log("[twitter] login");
+    const twitterClient = new TwitterApi({
+      appKey: process.env.TWITTER_API_KEY || "",
+      appSecret: process.env.TWITTER_API_KEY_SECRET || "",
+      accessToken: process.env.TWITTER_ACCESS_TOKEN || "",
+      accessSecret: process.env.TWITTER_ACCESS_TOKEN_SECRET || "",
+    });
+
+    const text = source.text;
+    const textTooLong = text.length > 280;
+    let tweetText = textTooLong
+      ? text.slice(0, 252) + "…" + ` ${status.uri}`
+      : text;
+
+    if (status.spoilerText) {
+      tweetText = `[cw ${status.spoilerText}] ${status.uri}`;
+    }
+
+    const mediaIds = await Promise.all(
+      mediaFiles
+        .filter(() => {
+          return !status.spoilerText;
+        })
+        .slice(0, 4)
+        .map((photo) => {
+          return new Promise<string>(async (resolve) => {
+            console.log(`[twitter] uploading ${photo.filename}`);
+            const mediaId = await twitterClient.v1.uploadMedia(
+              photo.filename,
+              {},
+            );
+            if (photo.altText) {
+              await twitterClient.v1.createMediaMetadata(mediaId, {
+                alt_text: {
+                  text: photo.altText,
+                },
+              });
+            }
+            resolve(mediaId);
+          });
+        }),
+    );
+
+    console.log("[twitter] tweeting");
+
+    const maybeInReplyToId =
+      (status.inReplyToId &&
+        findPost.fromMastodon.toTwitter(status.inReplyToId)) ||
+      undefined;
+
+    return await twitterClient.v2.tweet(tweetText, {
+      // @ts-expect-error
+      media: mediaIds.length
+        ? {
+            media_ids: mediaIds,
+          }
+        : undefined,
+      reply: maybeInReplyToId
+        ? {
+            in_reply_to_tweet_id: maybeInReplyToId,
+          }
+        : undefined,
+    });
+  } catch (e) {
+    console.error(e);
+  }
 }

--- a/src/helpers/twitter.ts
+++ b/src/helpers/twitter.ts
@@ -2,6 +2,7 @@ import { stream } from "undici";
 import fs from "node:fs";
 import path from "node:path";
 import { DownloadedMedia } from "./commonTypes";
+import { makeMediaFilepath } from "./media";
 
 export async function downloadTwitterMedia(tweet: APITweet) {
   return await Promise.all(
@@ -13,11 +14,11 @@ export async function downloadTwitterMedia(tweet: APITweet) {
           {
             method: "GET",
           },
-          () => fs.createWriteStream(path.basename(photoOrVideo.url)),
+          () => fs.createWriteStream(makeMediaFilepath(photoOrVideo.url)),
         );
 
         resolve({
-          filename: path.basename(photoOrVideo.url),
+          filename: makeMediaFilepath(photoOrVideo.url),
           altText: (photoOrVideo as any).altText || "",
         });
       });

--- a/src/routes/mastodonRoutes.ts
+++ b/src/routes/mastodonRoutes.ts
@@ -1,6 +1,7 @@
 import { type Express, type Response } from "express";
 import { parseQuery } from "./routeHelpers";
 import {
+  downloadMastodonMedia,
   getStatusAndSourceFromMastodonUrl,
   MastodonStatusNotFoundError,
 } from "../helpers/mastodon";
@@ -43,9 +44,12 @@ async function handleMastodonPost(options: {
 }) {
   const { res, status, source, postToTwitter, postToBluesky, postToCohost } =
     options;
+
+  const mediaFiles = await downloadMastodonMedia(status);
+
   if (postToCohost) {
     try {
-      const chost = await postMastodonToCohost(status, source, []);
+      const chost = await postMastodonToCohost(status, source, mediaFiles);
       if (chost) {
         savePost.fromMastodon.toCohost(status.id, chost);
         console.log("Chost!");

--- a/src/routes/mastodonRoutes.ts
+++ b/src/routes/mastodonRoutes.ts
@@ -1,6 +1,9 @@
 import { type Express, type Response } from "express";
 import { parseQuery } from "./routeHelpers";
-import { getJsonFromMastodon } from "../mastodon";
+import {
+  getStatusAndSourceFromMastodonUrl,
+  MastodonStatusNotFoundError,
+} from "../helpers/mastodon";
 import { mastodon } from "masto";
 
 export function mountMastodonRoutes(app: Express) {
@@ -8,7 +11,7 @@ export function mountMastodonRoutes(app: Express) {
     try {
       const { url, services } = parseQuery(req);
 
-      const json = await getJsonFromMastodon(url.toString());
+      const json = await getStatusAndSourceFromMastodonUrl(url.toString());
       console.log(json);
 
       return handleMastodonPost({
@@ -20,6 +23,10 @@ export function mountMastodonRoutes(app: Express) {
       });
     } catch (e) {
       console.error(e);
+
+      if (e instanceof MastodonStatusNotFoundError) {
+        return res.sendStatus(404);
+      }
       return res.sendStatus(400);
     }
   });

--- a/src/routes/mastodonRoutes.ts
+++ b/src/routes/mastodonRoutes.ts
@@ -11,6 +11,7 @@ import { postMastodonToCohost } from "../helpers/cohost";
 import { savePost } from "../storage";
 import { compact } from "lodash";
 import { postMastodonToBluesky } from "../helpers/bsky";
+import { postMastodonToTwitter } from "../helpers/twitter";
 
 export function mountMastodonRoutes(app: Express) {
   app.get("/fromMastodon", async (req, res) => {
@@ -23,7 +24,7 @@ export function mountMastodonRoutes(app: Express) {
         res,
         ...json,
         postToTwitter: services.includes("twitter"),
-        postToBluesky: services.includes("bsky") || true,
+        postToBluesky: services.includes("bsky"),
         postToCohost: services.includes("cohost"),
       });
     } catch (e) {
@@ -69,6 +70,19 @@ async function handleMastodonPost(options: {
         if (blueskyPost) {
           savePost.fromMastodon.toBluesky(status.id, blueskyPost.uri);
           console.log("Bluesky!");
+        }
+      },
+    postToTwitter &&
+      async function () {
+        const twitterPost = await postMastodonToTwitter(
+          status,
+          source,
+          mediaFiles,
+        );
+
+        if (twitterPost) {
+          savePost.fromMastodon.toTwitter(status.id, twitterPost.data.id);
+          console.log("Twitter!");
         }
       },
   ]);

--- a/src/routes/mastodonRoutes.ts
+++ b/src/routes/mastodonRoutes.ts
@@ -1,0 +1,35 @@
+import { type Express, type Response } from "express";
+import { parseQuery } from "./routeHelpers";
+import { getJsonFromMastodon } from "../mastodon";
+import { mastodon } from "masto";
+
+export function mountMastodonRoutes(app: Express) {
+  app.get("/fromMastodon", async (req, res) => {
+    try {
+      const { url, services } = parseQuery(req);
+
+      const json = await getJsonFromMastodon(url.toString());
+      console.log(json);
+
+      return handleMastodonPost({
+        res,
+        ...json,
+        postToTwitter: services.includes("twitter"),
+        postToBluesky: services.includes("bsky"),
+        postToCohost: services.includes("cohost"),
+      });
+    } catch (e) {
+      console.error(e);
+      return res.sendStatus(400);
+    }
+  });
+}
+
+async function handleMastodonPost(options: {
+  res: Response;
+  status: mastodon.v1.Status;
+  source: mastodon.v1.StatusSource;
+  postToTwitter: boolean;
+  postToBluesky: boolean;
+  postToCohost: boolean;
+}) {}

--- a/src/routes/routeHelpers.ts
+++ b/src/routes/routeHelpers.ts
@@ -1,0 +1,16 @@
+import { type Request } from "express";
+
+export function parseQuery(req: Request) {
+  const url = new URL(
+    String(req.query.url || "")
+      .replace(/^"/gi, "")
+      .replace(/"$/gi, ""),
+  );
+
+  const services = String(req.query.services).split(",");
+
+  return {
+    url,
+    services,
+  };
+}

--- a/src/routes/twitterRoutes.ts
+++ b/src/routes/twitterRoutes.ts
@@ -6,7 +6,7 @@ import { postTweetToCohost } from "../helpers/cohost";
 import { postTweetToMastodon } from "../helpers/mastodon";
 import { downloadTwitterMedia } from "../helpers/twitter";
 import { expandUrlsInTweetText } from "../redirects";
-import { Services, saveStatus } from "../storage";
+import { savePost } from "../storage";
 
 import { type Express, type Response } from "express";
 import { baseRequestOptions } from "../server";
@@ -72,7 +72,7 @@ export function mountTwitterRoutes(app: Express) {
             console.log("Posting to Mastodon...");
             const toot = await postTweetToMastodon(fxStatus.tweet, mediaFiles);
             const tootId = toot.id;
-            saveStatus(tweetId, tootId, Services.Mastodon);
+            savePost.fromTwitter.toMastodon(tweetId, tootId);
             console.log("Toot!");
           },
         postToBluesky &&
@@ -83,14 +83,14 @@ export function mountTwitterRoutes(app: Express) {
               mediaFiles,
             );
             const blueskyPostId = blueskyPost.uri;
-            saveStatus(tweetId, blueskyPostId, Services.Bluesky);
+            savePost.fromTwitter.toBluesky(tweetId, blueskyPostId);
             console.log("Post!");
           },
         postToCohost &&
           async function () {
             console.log("Posting to cohost...");
             const chost = await postTweetToCohost(fxStatus.tweet, mediaFiles);
-            saveStatus(tweetId, chost, Services.Cohost);
+            savePost.fromTwitter.toCohost(tweetId, chost);
             console.log("Chost!");
           },
       ]);

--- a/src/routes/twitterRoutes.ts
+++ b/src/routes/twitterRoutes.ts
@@ -1,0 +1,111 @@
+import { compact } from "lodash";
+import fs from "node:fs";
+import { request } from "undici";
+import { postTweetToBluesky } from "../bsky";
+import { postTweetToCohost } from "../cohost";
+import { postTweetToMastodon } from "../mastodon";
+import { downloadMedia } from "../media";
+import { expandUrlsInTweetText } from "../redirects";
+import { Services, saveStatus } from "../storage";
+
+import { type Express, type Response } from "express";
+import { baseRequestOptions } from "../server";
+
+export function mountTwitterRoutes(app: Express) {
+  app.get("/fromTwitter", async (req, res) => {
+    try {
+      const url = new URL(
+        String(req.query.url || "")
+          .replace(/^"/gi, "")
+          .replace(/"$/gi, ""),
+      );
+      const services = String(req.query.services).split(",");
+      const id = url.pathname.split("/").pop();
+
+      return handleTweet({
+        tweetId: String(id),
+        res,
+        postToMastodon: services.includes("mastodon"),
+        postToBluesky: services.includes("bsky"),
+        postToCohost: services.includes("cohost"),
+      });
+    } catch (e) {
+      console.error(e);
+      return res.sendStatus(400);
+    }
+  });
+
+  async function handleTweet(options: {
+    tweetId: string;
+    res: Response;
+    postToMastodon: boolean;
+    postToBluesky: boolean;
+    postToCohost: boolean;
+  }) {
+    const { tweetId, res, postToMastodon, postToBluesky, postToCohost } =
+      options;
+    if (!postToMastodon && !postToBluesky && !postToCohost) {
+      return res
+        .status(400)
+        .send(
+          "No services selected! You need to pass `services=mastodon,bsky,cohost`",
+        );
+    }
+    try {
+      let fxStatus = (await (
+        await request(
+          `https://api.fxtwitter.com/status/${tweetId}`,
+          baseRequestOptions,
+        )
+      ).body.json()) as { tweet: APITweet };
+
+      if (
+        fxStatus.tweet.author.screen_name?.toLowerCase() !==
+        process.env.SCREEN_NAME
+      ) {
+        return res.status(403).send(`You can't post someone else's tweet!`);
+      }
+
+      fxStatus.tweet.text = await expandUrlsInTweetText(fxStatus.tweet.text);
+
+      const mediaFiles = await downloadMedia(fxStatus.tweet);
+
+      const postingPromises = compact([
+        postToMastodon &&
+          async function () {
+            console.log("Posting to Mastodon...");
+            const toot = await postTweetToMastodon(fxStatus.tweet, mediaFiles);
+            const tootId = toot.id;
+            saveStatus(tweetId, tootId, Services.Mastodon);
+            console.log("Toot!");
+          },
+        postToBluesky &&
+          async function () {
+            console.log("Posting to bsky...");
+            const skeet = await postTweetToBluesky(fxStatus.tweet, mediaFiles);
+            const skeetId = skeet.uri;
+            saveStatus(tweetId, skeetId, Services.Bluesky);
+            console.log("Skeet!");
+          },
+        postToCohost &&
+          async function () {
+            console.log("Posting to cohost...");
+            const chost = await postTweetToCohost(fxStatus.tweet, mediaFiles);
+            saveStatus(tweetId, chost, Services.Cohost);
+            console.log("Chost!");
+          },
+      ]);
+
+      await Promise.all(postingPromises.map((p) => p()));
+
+      mediaFiles.forEach((file) => {
+        fs.unlinkSync(file.filename);
+      });
+
+      return res.sendStatus(200);
+    } catch (e) {
+      console.error(e);
+      return res.sendStatus(404);
+    }
+  }
+}

--- a/src/routes/twitterRoutes.ts
+++ b/src/routes/twitterRoutes.ts
@@ -106,7 +106,7 @@ export function mountTwitterRoutes(app: Express) {
       return res.sendStatus(200);
     } catch (e) {
       console.error(e);
-      return res.sendStatus(404);
+      return res.sendStatus(500);
     }
   }
 }

--- a/src/routes/twitterRoutes.ts
+++ b/src/routes/twitterRoutes.ts
@@ -1,9 +1,9 @@
 import { compact } from "lodash";
 import fs from "node:fs";
 import { request } from "undici";
-import { postTweetToBluesky } from "../bsky";
-import { postTweetToCohost } from "../cohost";
-import { postTweetToMastodon } from "../mastodon";
+import { postTweetToBluesky } from "../helpers/bsky";
+import { postTweetToCohost } from "../helpers/cohost";
+import { postTweetToMastodon } from "../helpers/mastodon";
 import { downloadTwitterMedia } from "../helpers/twitter";
 import { expandUrlsInTweetText } from "../redirects";
 import { Services, saveStatus } from "../storage";

--- a/src/routes/twitterRoutes.ts
+++ b/src/routes/twitterRoutes.ts
@@ -90,8 +90,10 @@ export function mountTwitterRoutes(app: Express) {
           async function () {
             console.log("Posting to cohost...");
             const chost = await postTweetToCohost(fxStatus.tweet, mediaFiles);
-            savePost.fromTwitter.toCohost(tweetId, chost);
-            console.log("Chost!");
+            if (chost) {
+              savePost.fromTwitter.toCohost(tweetId, chost);
+              console.log("Chost!");
+            }
           },
       ]);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import * as dotenv from "dotenv";
+import fs from "node:fs";
 import express from "express";
 import { setupCleanup } from "./cleanup";
 import { mountTwitterRoutes } from "./routes/twitterRoutes";
@@ -9,6 +10,11 @@ dotenv.config();
 const app = express();
 const port = process.env.PORT || 8080;
 const isDev = process.env.NODE_ENV !== "production";
+
+if (!fs.existsSync("media")) {
+  console.log("Creating media folder");
+  fs.mkdirSync("media");
+}
 
 restoreFromDisk();
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import express from "express";
 import { setupCleanup } from "./cleanup";
 import { mountTwitterRoutes } from "./routes/twitterRoutes";
-import { restoreFromDisk, writeToDisk } from "./storage";
+import { restoreFromDisk, savePost, writeToDisk } from "./storage";
 import { mountMastodonRoutes } from "./routes/mastodonRoutes";
 
 dotenv.config();
@@ -42,10 +42,6 @@ mountMastodonRoutes(app);
 
 app.all("*", (req, res) => {
   res.sendStatus(404);
-});
-
-setupCleanup(() => {
-  writeToDisk();
 });
 
 app.listen(port, () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,7 @@ import express from "express";
 import { setupCleanup } from "./cleanup";
 import { mountTwitterRoutes } from "./routes/twitterRoutes";
 import { restoreFromDisk, writeToDisk } from "./storage";
+import { mountMastodonRoutes } from "./routes/mastodonRoutes";
 
 dotenv.config();
 const app = express();
@@ -31,6 +32,7 @@ app.get("/", (_req, res) => {
 });
 
 mountTwitterRoutes(app);
+mountMastodonRoutes(app);
 
 app.all("*", (req, res) => {
   res.sendStatus(404);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,15 +1,9 @@
 import * as dotenv from "dotenv";
-import express, { Response } from "express";
-import { compact } from "lodash";
-import fs from "node:fs";
-import { request } from "undici";
-import { postTweetToBluesky } from "./bsky";
+import express from "express";
 import { setupCleanup } from "./cleanup";
-import { postTweetToCohost } from "./cohost";
-import { postTweetToMastodon } from "./mastodon";
-import { downloadMedia } from "./media";
-import { expandUrlsInTweetText } from "./redirects";
-import { Services, restoreFromDisk, saveStatus, writeToDisk } from "./storage";
+import { mountTwitterRoutes } from "./routes/twitterRoutes";
+import { restoreFromDisk, writeToDisk } from "./storage";
+
 dotenv.config();
 const app = express();
 const port = process.env.PORT || 8080;
@@ -17,7 +11,7 @@ const isDev = process.env.NODE_ENV !== "production";
 
 restoreFromDisk();
 
-const baseRequestOptions = {
+export const baseRequestOptions = {
   headers: {
     "User-Agent": "Tweet-Forker/1.0 (+https://github.com/eramdam/tweet-forker)",
   },
@@ -36,101 +30,7 @@ app.get("/", (_req, res) => {
   return res.sendStatus(200);
 });
 
-app.get("/u", async (req, res) => {
-  try {
-    const url = new URL(
-      String(req.query.url || "")
-        .replace(/^"/gi, "")
-        .replace(/"$/gi, ""),
-    );
-    const services = String(req.query.services).split(",");
-    const id = url.pathname.split("/").pop();
-
-    return handleStatus({
-      tweetId: String(id),
-      res,
-      mastodon: services.includes("mastodon"),
-      bsky: services.includes("bsky"),
-      cohost: services.includes("cohost"),
-    });
-  } catch (e) {
-    console.error(e);
-    return res.sendStatus(400);
-  }
-});
-
-async function handleStatus(options: {
-  tweetId: string;
-  res: Response;
-  mastodon: boolean;
-  bsky: boolean;
-  cohost: boolean;
-}) {
-  const { tweetId, res, mastodon, bsky, cohost } = options;
-  if (!mastodon && !bsky && !cohost) {
-    return res
-      .status(400)
-      .send(
-        "No services selected! You need to pass `services=mastodon,bsky,cohost`",
-      );
-  }
-  try {
-    let fxStatus = (await (
-      await request(
-        `https://api.fxtwitter.com/status/${tweetId}`,
-        baseRequestOptions,
-      )
-    ).body.json()) as { tweet: APITweet };
-
-    if (
-      fxStatus.tweet.author.screen_name?.toLowerCase() !==
-      process.env.SCREEN_NAME
-    ) {
-      return res.status(403).send(`You can't post someone else's tweet!`);
-    }
-
-    fxStatus.tweet.text = await expandUrlsInTweetText(fxStatus.tweet.text);
-
-    const mediaFiles = await downloadMedia(fxStatus.tweet);
-
-    const postingPromises = compact([
-      mastodon &&
-        async function () {
-          console.log("Posting to Mastodon...");
-          const toot = await postTweetToMastodon(fxStatus.tweet, mediaFiles);
-          const tootId = toot.id;
-          saveStatus(tweetId, tootId, Services.Mastodon);
-          console.log("Toot!");
-        },
-      bsky &&
-        async function () {
-          console.log("Posting to bsky...");
-          const skeet = await postTweetToBluesky(fxStatus.tweet, mediaFiles);
-          const skeetId = skeet.uri;
-          saveStatus(tweetId, skeetId, Services.Bluesky);
-          console.log("Skeet!");
-        },
-      cohost &&
-        async function () {
-          console.log("Posting to cohost...");
-          const chost = await postTweetToCohost(fxStatus.tweet, mediaFiles);
-          saveStatus(tweetId, chost, Services.Cohost);
-          console.log("Chost!");
-        },
-    ]);
-
-    await Promise.all(postingPromises.map((p) => p()));
-
-    mediaFiles.forEach((file) => {
-      fs.unlinkSync(file.filename);
-    });
-
-    return res.sendStatus(200);
-  } catch (e) {
-    console.error(e);
-    return res.sendStatus(404);
-  }
-}
+mountTwitterRoutes(app);
 
 app.all("*", (req, res) => {
   res.sendStatus(404);

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -18,7 +18,7 @@ export function saveStatus(
 export function findTootFromTweetId(twitterId: string) {
   return cache.get(`${twitterId}-${Services.Mastodon}`);
 }
-export function findSkeetFromTweetId(twitterId: string) {
+export function findBlueskyPostFromTweetId(twitterId: string) {
   return cache.get(`${twitterId}-${Services.Bluesky}`);
 }
 export function findChostFromTweetId(twitterId: string) {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -15,7 +15,7 @@ function savePostBase(
   foreignService: Omit<Services, typeof source>,
 ) {
   cache.set(`${source}-${id}-${foreignService}`, foreignId);
-  console.log(`${source}-${id}-${foreignService}`, foreignId);
+  writeToDisk();
 }
 
 export const savePost = {
@@ -81,7 +81,7 @@ export function restoreFromDisk() {
     const raw = fs.readFileSync("./cache.json", { encoding: "utf-8" });
     cache = new Map<string, string>(JSON.parse(raw));
   } catch (e) {
-    //
+    cache = new Map<string, string>();
   }
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,28 +2,79 @@ import fs from "fs";
 let cache = new Map<string, string>();
 
 export enum Services {
+  Twitter = "twitter",
   Mastodon = "mastodon",
   Bluesky = "bsky",
   Cohost = "cohost",
 }
 
-export function saveStatus(
-  twitterId: string,
+function savePostBase(
+  source: Services,
+  id: string,
   foreignId: string,
-  service: Services,
+  foreignService: Omit<Services, typeof source>,
 ) {
-  cache.set(`${twitterId}-${service}`, foreignId);
+  cache.set(`${source}-${id}-${foreignService}`, foreignId);
+  console.log(`${source}-${id}-${foreignService}`, foreignId);
 }
 
-export function findTootFromTweetId(twitterId: string) {
-  return cache.get(`${twitterId}-${Services.Mastodon}`);
+export const savePost = {
+  fromTwitter: {
+    toCohost: (id: string, foreignId: string) => {
+      savePostBase(Services.Twitter, id, foreignId, Services.Cohost);
+    },
+    toBluesky: (id: string, foreignId: string) => {
+      savePostBase(Services.Twitter, id, foreignId, Services.Bluesky);
+    },
+    toMastodon: (id: string, foreignId: string) => {
+      savePostBase(Services.Twitter, id, foreignId, Services.Mastodon);
+    },
+  },
+  fromMastodon: {
+    toCohost: (id: string, foreignId: string) => {
+      savePostBase(Services.Mastodon, id, foreignId, Services.Cohost);
+    },
+    toBluesky: (id: string, foreignId: string) => {
+      savePostBase(Services.Mastodon, id, foreignId, Services.Bluesky);
+    },
+    toTwitter: (id: string, foreignId: string) => {
+      savePostBase(Services.Mastodon, id, foreignId, Services.Twitter);
+    },
+  },
+};
+
+function findPostFromSource(
+  source: Services,
+  sourceId: string,
+  foreignService: Omit<Services, typeof source>,
+) {
+  return cache.get(`${Services.Mastodon}-${sourceId}-${foreignService}`);
 }
-export function findBlueskyPostFromTweetId(twitterId: string) {
-  return cache.get(`${twitterId}-${Services.Bluesky}`);
-}
-export function findChostFromTweetId(twitterId: string) {
-  return cache.get(`${twitterId}-${Services.Cohost}`);
-}
+
+export const findPost = {
+  fromTwitter: {
+    toCohost: (id: string) => {
+      return findPostFromSource(Services.Twitter, id, Services.Cohost);
+    },
+    toBluesky: (id: string) => {
+      return findPostFromSource(Services.Twitter, id, Services.Bluesky);
+    },
+    toMastodon: (id: string) => {
+      return findPostFromSource(Services.Twitter, id, Services.Mastodon);
+    },
+  },
+  fromMastodon: {
+    toCohost: (id: string) => {
+      return findPostFromSource(Services.Mastodon, id, Services.Cohost);
+    },
+    toBluesky: (id: string) => {
+      return findPostFromSource(Services.Mastodon, id, Services.Bluesky);
+    },
+    toTwitter: (id: string) => {
+      return findPostFromSource(Services.Mastodon, id, Services.Twitter);
+    },
+  },
+};
 
 export function restoreFromDisk() {
   try {


### PR DESCRIPTION
# 2.0.0

- The `/u` endpoint has been renamed to `/fromTwitter`
- Add a `/fromMastodon` endpoint, this endpoint will post to:
  - Cohost
    - Content warnings and audio attachments are supported
  - Bluesky
    - If the Mastodon post is too long, it will be posted as a tweet with a link to the original post
    - If the Mastodon post has a content warning, it will be posted as a tweet with a link to the original post
  - Twitter
    - If the Mastodon post is too long, it will be posted as a tweet with a link to the original post
    - If the Mastodon post has a content warning, it will be posted as a tweet with a link to the original post
- media files are now stored in the `media` folder
